### PR TITLE
Avoid CTAD edge-case with spans

### DIFF
--- a/src/aglio/serializer.hpp
+++ b/src/aglio/serializer.hpp
@@ -73,13 +73,13 @@ struct serializer<T, Size_t> {
     template<typename Buffer>
     static constexpr bool serialize(T const& v,
                                     Buffer&  buffer) {
-        return buffer.insert(std::as_bytes(std::span{std::addressof(v), 1}));
+        return buffer.insert(std::as_bytes(std::span<T const, 1>{std::addressof(v), 1}));
     }
 
     template<typename Buffer>
     static constexpr bool deserialize(T&      v,
                                       Buffer& buffer) {
-        return buffer.extract(std::as_writable_bytes(std::span{std::addressof(v), 1}));
+        return buffer.extract(std::as_writable_bytes(std::span<T, 1>{std::addressof(v), 1}));
     }
 };
 


### PR DESCRIPTION
There's a sneaky bug waiting to happen in aglio's serializer.

aglio initializes a span in 2 places like this: `std::span{std::addressof(v), 1}`.
Prior to C++26, this uses std::span's [second constructor](https://en.cppreference.com/w/cpp/container/span/span.html):
```cpp
template< class It >
explicit(extent != std::dynamic_extent)
constexpr span( It first, size_type count );
```
But C++26 adds an initializer-list constructor, which is apparently preferred for certain types of v such as bool when constructing the span with braces, meaning the span would now contain 2 elements instead of 1!

This PR fixes this bug by specifying the type of the result span, thus restricting the number of valid constructors to one.
This also gets rid of the associated narrowing conversion warning.